### PR TITLE
fix: dev world not deleted

### DIFF
--- a/src/main/java/hypersquare/hypersquare/Hypersquare.java
+++ b/src/main/java/hypersquare/hypersquare/Hypersquare.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.logging.Logger;
 
 public final class Hypersquare extends JavaPlugin {
     public static String DB_PASS;
@@ -70,7 +71,7 @@ public final class Hypersquare extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        Bukkit.getLogger().info("Hypersquare starting up...");
+        getLogger().info("Hypersquare starting up...");
         instance = this;
         // Register Dependencies
         slimePlugin = (SlimePlugin) Bukkit.getPluginManager().getPlugin("SlimeWorldManager"); // Slime
@@ -118,13 +119,13 @@ public final class Hypersquare extends JavaPlugin {
             world.setKeepSpawnInMemory(false);
         }
 
-        Bukkit.getLogger().info("Hypersquare is ready!");
+        getLogger().info("Hypersquare is ready!");
     }
 
     @Override
     public void onDisable() {
         saveLastUsedWorldNumber();
-        Bukkit.getLogger().info("Byeee!!");
+        getLogger().info("Byeee!!");
     }
 
     public void registerCommands(CommandManager commandManager) {

--- a/src/main/java/hypersquare/hypersquare/menu/CreatePlotsMenu.java
+++ b/src/main/java/hypersquare/hypersquare/menu/CreatePlotsMenu.java
@@ -45,51 +45,51 @@ public class CreatePlotsMenu {
 
         basic.onClick(() -> {
             if (usedBasic < maxBasic) {
+                player.closeInventory();
                 int plotID = lastUsedWorldNumber;
                 Plot.createPlot(player, plotID, Hypersquare.slimePlugin, player.getUniqueId().toString(), "plot_template_basic");
                 lastUsedWorldNumber++;
                 PlotDatabase.setRecentPlotID(lastUsedWorldNumber);
-                player.closeInventory();
             }
         });
 
         large.onClick(() -> {
             if (usedLarge < maxLarge) {
+                player.closeInventory();
                 int plotID = lastUsedWorldNumber;
                 Plot.createPlot(player, plotID, Hypersquare.slimePlugin, player.getUniqueId().toString(), "plot_template_large");
                 lastUsedWorldNumber++;
                 PlotDatabase.setRecentPlotID(lastUsedWorldNumber);
-                player.closeInventory();
             }
         });
 
         huge.onClick(() -> {
             if (usedhuge < maxhuge) {
+                player.closeInventory();
                 int plotID = lastUsedWorldNumber;
                 Plot.createPlot(player, plotID, Hypersquare.slimePlugin, player.getUniqueId().toString(), "plot_template_massive");
                 lastUsedWorldNumber++;
                 PlotDatabase.setRecentPlotID(lastUsedWorldNumber);
-                player.closeInventory();
             }
         });
 
         massive.onClick(() -> {
             if (usedmassive < maxmassive) {
+                player.closeInventory();
                 int plotID = lastUsedWorldNumber;
                 Plot.createPlot(player, plotID, Hypersquare.slimePlugin, player.getUniqueId().toString(), "plot_template_huge");
                 lastUsedWorldNumber++;
                 PlotDatabase.setRecentPlotID(lastUsedWorldNumber);
-                player.closeInventory();
             }
         });
 
         gigantic.onClick(() -> {
             if (usedGigantic < maxGigantic) {
+                player.closeInventory();
                 int plotID = lastUsedWorldNumber;
                 Plot.createPlot(player, plotID, Hypersquare.slimePlugin, player.getUniqueId().toString(), "plot_template_gigantic");
                 lastUsedWorldNumber++;
                 PlotDatabase.setRecentPlotID(lastUsedWorldNumber);
-                player.closeInventory();
             }
         });
 

--- a/src/main/java/hypersquare/hypersquare/plot/Plot.java
+++ b/src/main/java/hypersquare/hypersquare/plot/Plot.java
@@ -89,8 +89,11 @@ public class Plot {
 
     public static void deletePlot(int plotID) throws UnknownWorldException, IOException {
         String worldName = "hs." + plotID;
+        String codeWorldName = "hs.code." + plotID;
         SlimeLoader file = Hypersquare.slimePlugin.getLoader("mongodb");
         Bukkit.unloadWorld(Bukkit.getWorld(worldName), true);
+        Bukkit.unloadWorld(Bukkit.getWorld(codeWorldName), true);
         file.deleteWorld(worldName);
+        file.deleteWorld(codeWorldName);
     }
 }


### PR DESCRIPTION
Fixes in the PR:
* Dev world not deleting when plot is unclaimed
* Inventory not immediately closing after joining a plot from menu
* Use getLogger() instead of Bukkit.getLogger() in the main class
